### PR TITLE
Fix signup page filename and references

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -34,7 +34,7 @@ export default function TabLayout() {
       />
 
       <Tabs.Screen
-        name="singup"
+        name="signup"
         options={{
           title: "新規登録",
           headerTitleStyle: { color: text },

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -68,7 +68,7 @@ export default function LoginPage() {
           <ThemedText style={styles.footerText}>
             まだ登録してませんか？
           </ThemedText>
-          <Link href={"/(auth)/singup"} asChild replace>
+          <Link href={"/(auth)/signup"} asChild replace>
             <TouchableOpacity>
               <ThemedText type="link" style={styles.footerLink}>
                 登録

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -15,7 +15,7 @@ import { useThemeColor } from "@/hooks/useThemeColor";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 
-export default function SingupPage() {
+export default function SignupPage() {
   const tab = useThemeColor({}, "tab");
   const text = useThemeColor({}, "text");
 


### PR DESCRIPTION
## Summary
- rename `singup` to `signup`
- update links and screen definitions to use `signup`
- export `SignupPage` as default

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685376bf61bc8332ba4e173c8204f1b3